### PR TITLE
http: Fix bug in connection_lost.

### DIFF
--- a/lib/gruvi/http.py
+++ b/lib/gruvi/http.py
@@ -907,8 +907,8 @@ class HttpProtocol(MessageProtocol):
             if exc is None:
                 exc = HttpError('parse error: {}'.format(msg))
             if self._message:
-                self._message.body.feed_error(self._error)
-            self._queue.put_nowait(self._error)
+                self._message.body.feed_error(exc)
+            self._queue.put_nowait(exc)
         super(HttpProtocol, self).connection_lost(exc)
         if not self._server_side:
             self._queue.put_nowait(self._error)


### PR DESCRIPTION
The connection_lost handler of the HTTP protocol feeds self._error
into the queue, but that is only set by the super-class
implementation, which is called afterwards. Enqueue the exception
object that is passed to the super-class implementation instead.

This problem causes the caller to receive a HttpResponse object with
_message = None.
