### PR TITLE
http: Put exception in the queue in connection_lost

### DIFF
--- a/lib/gruvi/http.py
+++ b/lib/gruvi/http.py
@@ -1034,6 +1034,7 @@ class HttpProtocol(MessageProtocol):
         if self._header_value:
             self._save_header()
         self._message.body.buffer.feed_eof()
+        self._message = None
         self._maybe_pause_transport()
         return 0
 


### PR DESCRIPTION
The client fiber may already be blocked on the queue (in getresponse)
when connection_lost is invoked.

The code in getresponse already handles getting an exception from the
queue.